### PR TITLE
feature/not on top all the time

### DIFF
--- a/pyblish_lite/tree.py
+++ b/pyblish_lite/tree.py
@@ -7,8 +7,8 @@ from itertools import groupby
 
 class ProxyItem(model.TreeItem):
     def __init__(self, source_index):
-        super(ProxyItem, self).__init__()
         self.source_index = source_index
+        super(ProxyItem, self).__init__()
 
     def data(self, role=QtCore.Qt.DisplayRole):
         return self.source_index.data(role)

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -51,12 +51,14 @@ class Window(QtWidgets.QDialog):
     def __init__(self, controller, parent=None):
         super(Window, self).__init__(parent)
         icon = QtGui.QIcon(util.get_asset("img", "logo-extrasmall.png"))
-        self.setWindowFlags(self.windowFlags() |
-                            QtCore.Qt.WindowTitleHint |
-                            QtCore.Qt.WindowMaximizeButtonHint |
-                            QtCore.Qt.WindowMinimizeButtonHint |
-                            QtCore.Qt.WindowCloseButtonHint |
-                            QtCore.Qt.WindowStaysOnTopHint)
+        self.setWindowFlags(
+            self.windowFlags() |
+            QtCore.Qt.WindowTitleHint |
+            QtCore.Qt.WindowMaximizeButtonHint |
+            QtCore.Qt.WindowMinimizeButtonHint |
+            QtCore.Qt.WindowCloseButtonHint |
+            QtCore.Qt.Dialog
+        )
         self.setWindowIcon(icon)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -51,13 +51,18 @@ class Window(QtWidgets.QDialog):
     def __init__(self, controller, parent=None):
         super(Window, self).__init__(parent)
         icon = QtGui.QIcon(util.get_asset("img", "logo-extrasmall.png"))
+        if parent is None:
+            on_top_flag = QtCore.Qt.WindowStaysOnTopHint
+        else:
+            on_top_flag = QtCore.Qt.Dialog
+
         self.setWindowFlags(
             self.windowFlags() |
             QtCore.Qt.WindowTitleHint |
             QtCore.Qt.WindowMaximizeButtonHint |
             QtCore.Qt.WindowMinimizeButtonHint |
             QtCore.Qt.WindowCloseButtonHint |
-            QtCore.Qt.Dialog
+            on_top_flag
         )
         self.setWindowIcon(icon)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)


### PR DESCRIPTION
Issue:
- pyblish-lite is always on top of each application until is closed

Solution:
- make it possible to be on top only for the application

Changes:
- replaced QtCore.Qt.WindowStaysOnTopHint flag with QtCore.Qt.Dialog