### PR TITLE
hotfix/btns enabled when should

### DIFF
--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -818,6 +818,19 @@ class Window(QtWidgets.QDialog):
             instance_proxies = self.data["proxies"]["instances"]
             instance_proxies.layoutChanged.emit()
 
+        buttons = self.data["buttons"]
+        if buttons["play"].isEnabled():
+            buttons["play"].setEnabled(False)
+
+        if buttons["validate"].isEnabled():
+            buttons["validate"].setEnabled(False)
+
+        if buttons["reset"].isEnabled():
+            buttons["reset"].setEnabled(False)
+
+        if not buttons["reset"].isEnabled():
+            buttons["stop"].setEnabled(True)
+
         plugin_model = self.data["models"]["plugins"]
         index = plugin_model.items.index(plugin)
         index = plugin_model.createIndex(index, 0)


### PR DESCRIPTION
Partially fixed issue with enabling and disabling wrong buttons when process change plugin group (validators -> extractors).

- still remains wrong buttons setup when changing plugin group
    - this happens for a short time and would require refactor of pyblish-lite to solve fully