### PR TITLE
hotfix/families collecting fix

### DIFF
--- a/pyblish_lite/util.py
+++ b/pyblish_lite/util.py
@@ -76,8 +76,10 @@ def collect_families_from_instances(instances, only_active=False):
             if instance.data.get("publish") is False:
                 continue
         family = instance.data.get("family")
-        families = [family] if family else []
-        families += instance.data.get("families", [])
+        if family:
+            all_families.add(family)
+
+        families = instance.data.get("families") or tuple()
         for family in families:
             all_families.add(family)
 


### PR DESCRIPTION
- families collecting is more secure and won't crash if `instance.data["families"] is None`