### PR TITLE
Optional always exec the application

### DIFF
--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -25,6 +25,8 @@ def application():
     else:
         print("Using existing QApplication..")
         yield app
+        if os.environ.get("PYBLISH_LITE_ALWAYS_EXEC"):
+            app.exec_()
 
 
 def install_translator(app):


### PR DESCRIPTION
With environment variable "PYBLISH_LITE_ALWAYS_EXEC".

I have found this to be necessary for Harmony and Photoshop, but I not sure exactly why. Here is the discussion about it for PS; https://github.com/getavalon/core/pull/523