### PR TITLE
fixed recalculating positions of grouped instances to continue with r…

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -880,12 +880,10 @@ class ArtistProxy(QtCore.QAbstractProxyModel):
 
     def _remove_rows(self, parent_row, from_row, to_row):
         removed_rows = []
-        increment_num = None
+        increment_num = self.mapping_from[parent_row][from_row]
         _emit_last = None
         for row_num in reversed(range(from_row, to_row + 1)):
             row = self.mapping_from[parent_row].pop(row_num)
-            if increment_num is None:
-                increment_num = row
             _emit_last = row
             removed_rows.append(row)
 


### PR DESCRIPTION
# Grouped instances may crash pyblish-lite.
If instances are removed in specific order proxy model for Artist view cause issues. Proxy recalculations of mapping indexes are recalculated in wrong order.
### Instances have specific index to be able to map to grouped model:
```
- Group1 (none)
    - Instance1 (0)
- Group2 (none)
    - Instance2 (1)
    - Instance3 (2)
- Group3 (none)
    - Instance4 (3)
```

### When `Instance1` and `Group1` are removed, recalculations are right:
```
- Group2 (none)
    - Instance2 (0)
    - Instance3 (1)
- Group3 (none)
    - Instance4 (2)
```

### When `Instance2`, `Instance3` and `Group2` are removed, index is taken from first removed item so result is:
```
- Group3 (none)
    - Instance4 (1) # This should be (0)
```

Solved:
Index value is taken from `"first index to remove"` instead of `"first removed index"`.