### PR TITLE
Bugfix/fonts wight in delegates

### DIFF
--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -4,6 +4,7 @@
 	outline: none;
 	color: #ddd;
   	font-family: "Open Sans";
+	font-style: normal;
 }
 
 /* General CSS */
@@ -397,8 +398,7 @@ QToolButton {
 
 #EllidableLabel {
 	font-size: 16pt;
-	font-style: bold;
-	font-weight: 50;
+	font-weight: normal;
 }
 
 #PerspectiveScrollContent {
@@ -417,8 +417,7 @@ QToolButton {
 
 #PerspectiveIndicator {
 	font-size: 16pt;
-	font-style: bold;
-	font-weight: 50;
+	font-weight: normal;
 	padding: 5px;
 	background-color: #ffffff;
 	color: #333333;

--- a/pyblish_lite/app.py
+++ b/pyblish_lite/app.py
@@ -39,10 +39,21 @@ def install_translator(app):
 
 def install_fonts():
     database = QtGui.QFontDatabase()
+    fonts = [
+        "opensans/OpenSans-Bold.ttf",
+        "opensans/OpenSans-BoldItalic.ttf",
+        "opensans/OpenSans-ExtraBold.ttf",
+        "opensans/OpenSans-ExtraBoldItalic.ttf",
+        "opensans/OpenSans-Italic.ttf",
+        "opensans/OpenSans-Light.ttf",
+        "opensans/OpenSans-LightItalic.ttf",
+        "opensans/OpenSans-Regular.ttf",
+        "opensans/OpenSans-Semibold.ttf",
+        "opensans/OpenSans-SemiboldItalic.ttf",
+        "fontawesome/fontawesome-webfont.ttf"
+    ]
 
-    for font in (os.path.join("opensans", "OpenSans-Regular.ttf"),
-                 os.path.join("opensans", "OpenSans-Semibold.ttf"),
-                 os.path.join("fontawesome", "fontawesome-webfont.ttf")):
+    for font in fonts:
         path = util.get_asset("font", font)
 
         # TODO(marcus): Check if they are already installed first.
@@ -84,11 +95,7 @@ def show(parent=None):
         self._window.resize(*settings.WindowSize)
         self._window.setWindowTitle(settings.WindowTitle)
 
-        font = self._window.font()
-        font.setFamily("Open Sans")
-        font.setPointSize(8)
-        font.setWeight(400)
-
+        font = QtGui.QFont("Open Sans", 8, QtGui.QFont.Normal)
         self._window.setFont(font)
         self._window.setStyleSheet(css)
 

--- a/pyblish_lite/delegate.py
+++ b/pyblish_lite/delegate.py
@@ -25,9 +25,9 @@ colors = {
 scale_factors = {"darwin": 1.5}
 scale_factor = scale_factors.get(platform.system().lower(), 1.0)
 fonts = {
-    "h3": QtGui.QFont("Open Sans", 10 * scale_factor, 900),
-    "h4": QtGui.QFont("Open Sans", 8 * scale_factor, 400),
-    "h5": QtGui.QFont("Open Sans", 8 * scale_factor, 800),
+    "h3": QtGui.QFont("Open Sans", 10 * scale_factor, QtGui.QFont.Normal),
+    "h4": QtGui.QFont("Open Sans", 8 * scale_factor, QtGui.QFont.Normal),
+    "h5": QtGui.QFont("Open Sans", 8 * scale_factor, QtGui.QFont.DemiBold),
     "awesome6": QtGui.QFont("FontAwesome", 6 * scale_factor),
     "awesome10": QtGui.QFont("FontAwesome", 10 * scale_factor),
     "smallAwesome": QtGui.QFont("FontAwesome", 8 * scale_factor),


### PR DESCRIPTION
Issue:
Font (mainly in maya) was too thick. Is caused due to mixed registrations of Open Sans font. Pyblish-lite expected only 2 types of the font, but avalon-tools are registering all of them.

Solved:
Pyblish-lite also register all of them and uses racional values for font weight.